### PR TITLE
Add optional dry flag

### DIFF
--- a/action/ecs-deploy.go
+++ b/action/ecs-deploy.go
@@ -26,7 +26,7 @@ type ECSDeployTaskConfig interface {
 }
 
 // ECSDeploy deploy an ecs service
-func ECSDeploy(clusterName string, serviceName string, client ECSDeployClient, timeout time.Duration, config ECSDeployTaskConfig) error {
+func ECSDeploy(clusterName string, serviceName string, client ECSDeployClient, timeout time.Duration, config ECSDeployTaskConfig, dryRun bool) error {
 	if len(clusterName) == 0 {
 		return errors.New("cluster was not provided")
 	}
@@ -72,14 +72,20 @@ func ECSDeploy(clusterName string, serviceName string, client ECSDeployClient, t
 		return err
 	}
 
+	log.Println("These are the changes:")
+	log.Println(diff)
+
+	if dryRun {
+		log.Println("Not proceeding with the updates because this is a dry run :)")
+		return nil
+	}
+
 	newTaskDefinition, err := client.RegisterTaskDefinition(newTask)
 	if err != nil {
 		return err
 	}
 
 	log.Printf("Changing task definition\n  Old: %s\n  New: %s\n", *service.TaskDefinition, *newTaskDefinition.TaskDefinitionArn)
-	log.Println("These are the changes:")
-	log.Println(diff)
 
 	newService, err := client.UpdateTaskDefinition(service, newTaskDefinition)
 	if err != nil {

--- a/action/ecs-deploy_test.go
+++ b/action/ecs-deploy_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func Test_ECSDeploy_NoArgs(t *testing.T) {
-	err := ECSDeploy("", "", nil, time.Nanosecond, nil)
+	err := ECSDeploy("", "", nil, time.Nanosecond, nil, false)
 	assert.Error(t, err)
 }
 
@@ -23,14 +23,27 @@ func Test_ECSDeploy_TruePath(t *testing.T) {
 	const clusterName = "clusterA"
 	const serviceName = "serviceA"
 
+	family := "test-family"
+	serviceTaskArn := "test-family:0"
+	taskArn := "test-family:1"
 	timeout := time.Nanosecond
-	service := &ecssdk.Service{}
+	service := &ecssdk.Service{
+		TaskDefinition: &serviceTaskArn,
+	}
 	oldTask := &ecssdk.TaskDefinition{}
 	taskCopy := &ecssdk.RegisterTaskDefinitionInput{}
-	newTask := &ecssdk.RegisterTaskDefinitionInput{}
-	newTaskDefinition := &ecssdk.TaskDefinition{}
+	newTask := &ecssdk.RegisterTaskDefinitionInput{
+		ContainerDefinitions: make([]*ecssdk.ContainerDefinition, 0),
+		Family:               &family,
+	}
+	newTaskDefinition := &ecssdk.TaskDefinition{
+		TaskDefinitionArn: &taskArn,
+	}
 	newService := &ecssdk.Service{}
 	diff := &ecs.TaskConfigDiff{}
+	oldCpu := "1"
+	newCpu := "10"
+	diff.ChangeCPU(&oldCpu, &newCpu)
 
 	//#region mock
 	c := gomock.NewController(t)
@@ -41,14 +54,52 @@ func Test_ECSDeploy_TruePath(t *testing.T) {
 	client.EXPECT().CopyTaskDefinition(service).Return(taskCopy, oldTask, nil).Times(1)
 	client.EXPECT().RegisterTaskDefinition(newTask).Return(newTaskDefinition, nil).Times(1)
 	client.EXPECT().UpdateTaskDefinition(service, newTaskDefinition).Return(newService, nil).Times(1)
-	client.EXPECT().WaitUntilGood(newService, timeout).Return(nil).Times(1)
+	client.EXPECT().WaitUntilGood(newService, &timeout).Return(nil).Times(1)
 
 	cfg := mock.NewMockECSDeployTaskConfig(c)
 	cfg.EXPECT().ApplyTo(taskCopy).Return(newTask, diff).Times(1)
 
 	//#endregion
 
-	err := ECSDeploy(clusterName, serviceName, client, timeout, cfg)
+	err := ECSDeploy(clusterName, serviceName, client, timeout, cfg, false)
+	require.NoError(t, err)
+}
+
+func Test_ECSDeploy_DryRunPath(t *testing.T) {
+	const clusterName = "clusterA"
+	const serviceName = "serviceA"
+
+	family := "test-family"
+	serviceTaskArn := "test-family:0"
+	timeout := time.Nanosecond
+	service := &ecssdk.Service{
+		TaskDefinition: &serviceTaskArn,
+	}
+	oldTask := &ecssdk.TaskDefinition{}
+	taskCopy := &ecssdk.RegisterTaskDefinitionInput{}
+	newTask := &ecssdk.RegisterTaskDefinitionInput{
+		ContainerDefinitions: make([]*ecssdk.ContainerDefinition, 0),
+		Family:               &family,
+	}
+	diff := &ecs.TaskConfigDiff{}
+	oldCpu := "1"
+	newCpu := "10"
+	diff.ChangeCPU(&oldCpu, &newCpu)
+
+	//#region mock
+	c := gomock.NewController(t)
+
+	client := mock.NewMockECSDeployClient(c)
+	client.EXPECT().GetService(clusterName, serviceName).Return(service, nil).Times(1)
+	client.EXPECT().LooksGood(service).Return(true, nil).Times(1)
+	client.EXPECT().CopyTaskDefinition(service).Return(taskCopy, oldTask, nil).Times(1)
+
+	cfg := mock.NewMockECSDeployTaskConfig(c)
+	cfg.EXPECT().ApplyTo(taskCopy).Return(newTask, diff).Times(1)
+
+	//#endregion
+
+	err := ECSDeploy(clusterName, serviceName, client, timeout, cfg, true)
 	require.NoError(t, err)
 }
 
@@ -85,7 +136,7 @@ func Test_ECSDeploy_RollbackPath(t *testing.T) {
 
 	//#endregion
 
-	err := ECSDeploy(clusterName, serviceName, client, timeout, cfg)
+	err := ECSDeploy(clusterName, serviceName, client, timeout, cfg, false)
 	require.NoError(t, err)
 }
 
@@ -106,7 +157,7 @@ func Test_ECSDeploy_GetServiceError(t *testing.T) {
 	cfg := mock.NewMockECSDeployTaskConfig(c)
 	//#endregion
 
-	err := ECSDeploy(clusterName, serviceName, client, timeout, cfg)
+	err := ECSDeploy(clusterName, serviceName, client, timeout, cfg, false)
 	require.Equal(t, expectedError, err)
 }
 
@@ -128,7 +179,7 @@ func Test_ECSDeploy_LooksGoodError(t *testing.T) {
 	cfg := mock.NewMockECSDeployTaskConfig(c)
 	//#endregion
 
-	err := ECSDeploy(clusterName, serviceName, client, timeout, cfg)
+	err := ECSDeploy(clusterName, serviceName, client, timeout, cfg, false)
 	require.Equal(t, expectedError, err)
 }
 
@@ -151,6 +202,6 @@ func Test_ECSDeploy_CopyTaskDefinitionError(t *testing.T) {
 	cfg := mock.NewMockECSDeployTaskConfig(c)
 	//#endregion
 
-	err := ECSDeploy(clusterName, serviceName, client, timeout, cfg)
+	err := ECSDeploy(clusterName, serviceName, client, timeout, cfg, false)
 	require.Equal(t, expectedError, err)
 }

--- a/main.go
+++ b/main.go
@@ -45,6 +45,12 @@ func main() {
 				Usage:    "Disable colored output",
 				Required: false,
 			},
+			&cli.BoolFlag{
+				Name:     "dry",
+				Aliases:  []string{"d"},
+				Usage:    "Don't deploy just show what would change in the remote service",
+				Required: false,
+			},
 		},
 		Action: func(ctx *cli.Context) error {
 			color.NoColor = color.NoColor || ctx.Bool("no-color")
@@ -72,7 +78,7 @@ func main() {
 			}
 
 			client := ecs.BuildDefaultClient()
-			return action.ECSDeploy(cluster, service, client, ctx.Duration("timeout"), &cfg)
+			return action.ECSDeploy(cluster, service, client, ctx.Duration("timeout"), &cfg, ctx.Bool("dry"))
 		},
 	}
 


### PR DESCRIPTION
Now you can call `ecs-ship --dry` with the usual commands and have it not perform any changes just inform what it would do.
