### PR TITLE
Add a flag not to wait until the service is ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,14 @@ USAGE:
    ecs-deploy [options] <cluster> <service>
 
 VERSION:
-   1.0.0
+   1.1.0
 
 GLOBAL OPTIONS:
    --updates FILE, -u FILE          Use an input FILE to describe service updates (default: stdin)
    --timeout DURATION, -t DURATION  Wait this DURATION for the service to be correctly updated (default: 5m0s)
    --no-color, -n                   Disable colored output (default: false)
+   --no-wait, -w                    Disable waiting for updates to be completed. (default: false)
+   --dry, -d                        Don't deploy just show what would change in the remote service (default: false)
    --help, -h                       show help (default: false)
    --version, -v                    print the version (default: false)
 ```

--- a/action/ecs-deploy.go
+++ b/action/ecs-deploy.go
@@ -26,7 +26,7 @@ type ECSDeployTaskConfig interface {
 }
 
 // ECSDeploy deploy an ecs service
-func ECSDeploy(clusterName string, serviceName string, client ECSDeployClient, timeout time.Duration, config ECSDeployTaskConfig, dryRun bool) error {
+func ECSDeploy(clusterName string, serviceName string, client ECSDeployClient, timeout time.Duration, config ECSDeployTaskConfig, dryRun bool, noWait bool) error {
 	if len(clusterName) == 0 {
 		return errors.New("cluster was not provided")
 	}
@@ -90,6 +90,11 @@ func ECSDeploy(clusterName string, serviceName string, client ECSDeployClient, t
 	newService, err := client.UpdateTaskDefinition(service, newTaskDefinition)
 	if err != nil {
 		return err
+	}
+
+	if noWait {
+		log.Println("Not waiting for your service to reflect changes, check the console please :D")
+		return nil
 	}
 
 	log.Println("Waiting for the service to reflect the new changes...")

--- a/action/mock/ecs-deploy_mock.go
+++ b/action/mock/ecs-deploy_mock.go
@@ -5,67 +5,38 @@
 package mock_action
 
 import (
+	reflect "reflect"
+	time "time"
+
 	ecs "github.com/adroll/ecs-ship/ecs"
 	ecs0 "github.com/aws/aws-sdk-go/service/ecs"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
-	time "time"
 )
 
-// MockECSDeployClient is a mock of ECSDeployClient interface
+// MockECSDeployClient is a mock of ECSDeployClient interface.
 type MockECSDeployClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockECSDeployClientMockRecorder
 }
 
-// MockECSDeployClientMockRecorder is the mock recorder for MockECSDeployClient
+// MockECSDeployClientMockRecorder is the mock recorder for MockECSDeployClient.
 type MockECSDeployClientMockRecorder struct {
 	mock *MockECSDeployClient
 }
 
-// NewMockECSDeployClient creates a new mock instance
+// NewMockECSDeployClient creates a new mock instance.
 func NewMockECSDeployClient(ctrl *gomock.Controller) *MockECSDeployClient {
 	mock := &MockECSDeployClient{ctrl: ctrl}
 	mock.recorder = &MockECSDeployClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockECSDeployClient) EXPECT() *MockECSDeployClientMockRecorder {
 	return m.recorder
 }
 
-// GetService mocks base method
-func (m *MockECSDeployClient) GetService(clusterName, serviceName string) (*ecs0.Service, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetService", clusterName, serviceName)
-	ret0, _ := ret[0].(*ecs0.Service)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetService indicates an expected call of GetService
-func (mr *MockECSDeployClientMockRecorder) GetService(clusterName, serviceName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetService", reflect.TypeOf((*MockECSDeployClient)(nil).GetService), clusterName, serviceName)
-}
-
-// LooksGood mocks base method
-func (m *MockECSDeployClient) LooksGood(service *ecs0.Service) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LooksGood", service)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// LooksGood indicates an expected call of LooksGood
-func (mr *MockECSDeployClientMockRecorder) LooksGood(service interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LooksGood", reflect.TypeOf((*MockECSDeployClient)(nil).LooksGood), service)
-}
-
-// CopyTaskDefinition mocks base method
+// CopyTaskDefinition mocks base method.
 func (m *MockECSDeployClient) CopyTaskDefinition(service *ecs0.Service) (*ecs0.RegisterTaskDefinitionInput, *ecs0.TaskDefinition, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CopyTaskDefinition", service)
@@ -75,27 +46,43 @@ func (m *MockECSDeployClient) CopyTaskDefinition(service *ecs0.Service) (*ecs0.R
 	return ret0, ret1, ret2
 }
 
-// CopyTaskDefinition indicates an expected call of CopyTaskDefinition
+// CopyTaskDefinition indicates an expected call of CopyTaskDefinition.
 func (mr *MockECSDeployClientMockRecorder) CopyTaskDefinition(service interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyTaskDefinition", reflect.TypeOf((*MockECSDeployClient)(nil).CopyTaskDefinition), service)
 }
 
-// WaitUntilGood mocks base method
-func (m *MockECSDeployClient) WaitUntilGood(service *ecs0.Service, timeout *time.Duration) error {
+// GetService mocks base method.
+func (m *MockECSDeployClient) GetService(clusterName, serviceName string) (*ecs0.Service, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitUntilGood", service, timeout)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "GetService", clusterName, serviceName)
+	ret0, _ := ret[0].(*ecs0.Service)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// WaitUntilGood indicates an expected call of WaitUntilGood
-func (mr *MockECSDeployClientMockRecorder) WaitUntilGood(service, timeout interface{}) *gomock.Call {
+// GetService indicates an expected call of GetService.
+func (mr *MockECSDeployClientMockRecorder) GetService(clusterName, serviceName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilGood", reflect.TypeOf((*MockECSDeployClient)(nil).WaitUntilGood), service, timeout)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetService", reflect.TypeOf((*MockECSDeployClient)(nil).GetService), clusterName, serviceName)
 }
 
-// RegisterTaskDefinition mocks base method
+// LooksGood mocks base method.
+func (m *MockECSDeployClient) LooksGood(service *ecs0.Service) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LooksGood", service)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LooksGood indicates an expected call of LooksGood.
+func (mr *MockECSDeployClientMockRecorder) LooksGood(service interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LooksGood", reflect.TypeOf((*MockECSDeployClient)(nil).LooksGood), service)
+}
+
+// RegisterTaskDefinition mocks base method.
 func (m *MockECSDeployClient) RegisterTaskDefinition(input *ecs0.RegisterTaskDefinitionInput) (*ecs0.TaskDefinition, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterTaskDefinition", input)
@@ -104,13 +91,13 @@ func (m *MockECSDeployClient) RegisterTaskDefinition(input *ecs0.RegisterTaskDef
 	return ret0, ret1
 }
 
-// RegisterTaskDefinition indicates an expected call of RegisterTaskDefinition
+// RegisterTaskDefinition indicates an expected call of RegisterTaskDefinition.
 func (mr *MockECSDeployClientMockRecorder) RegisterTaskDefinition(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterTaskDefinition", reflect.TypeOf((*MockECSDeployClient)(nil).RegisterTaskDefinition), input)
 }
 
-// UpdateTaskDefinition mocks base method
+// UpdateTaskDefinition mocks base method.
 func (m *MockECSDeployClient) UpdateTaskDefinition(service *ecs0.Service, task *ecs0.TaskDefinition) (*ecs0.Service, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateTaskDefinition", service, task)
@@ -119,36 +106,50 @@ func (m *MockECSDeployClient) UpdateTaskDefinition(service *ecs0.Service, task *
 	return ret0, ret1
 }
 
-// UpdateTaskDefinition indicates an expected call of UpdateTaskDefinition
+// UpdateTaskDefinition indicates an expected call of UpdateTaskDefinition.
 func (mr *MockECSDeployClientMockRecorder) UpdateTaskDefinition(service, task interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTaskDefinition", reflect.TypeOf((*MockECSDeployClient)(nil).UpdateTaskDefinition), service, task)
 }
 
-// MockECSDeployTaskConfig is a mock of ECSDeployTaskConfig interface
+// WaitUntilGood mocks base method.
+func (m *MockECSDeployClient) WaitUntilGood(service *ecs0.Service, timeout *time.Duration) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitUntilGood", service, timeout)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitUntilGood indicates an expected call of WaitUntilGood.
+func (mr *MockECSDeployClientMockRecorder) WaitUntilGood(service, timeout interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilGood", reflect.TypeOf((*MockECSDeployClient)(nil).WaitUntilGood), service, timeout)
+}
+
+// MockECSDeployTaskConfig is a mock of ECSDeployTaskConfig interface.
 type MockECSDeployTaskConfig struct {
 	ctrl     *gomock.Controller
 	recorder *MockECSDeployTaskConfigMockRecorder
 }
 
-// MockECSDeployTaskConfigMockRecorder is the mock recorder for MockECSDeployTaskConfig
+// MockECSDeployTaskConfigMockRecorder is the mock recorder for MockECSDeployTaskConfig.
 type MockECSDeployTaskConfigMockRecorder struct {
 	mock *MockECSDeployTaskConfig
 }
 
-// NewMockECSDeployTaskConfig creates a new mock instance
+// NewMockECSDeployTaskConfig creates a new mock instance.
 func NewMockECSDeployTaskConfig(ctrl *gomock.Controller) *MockECSDeployTaskConfig {
 	mock := &MockECSDeployTaskConfig{ctrl: ctrl}
 	mock.recorder = &MockECSDeployTaskConfigMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockECSDeployTaskConfig) EXPECT() *MockECSDeployTaskConfigMockRecorder {
 	return m.recorder
 }
 
-// ApplyTo mocks base method
+// ApplyTo mocks base method.
 func (m *MockECSDeployTaskConfig) ApplyTo(input *ecs0.RegisterTaskDefinitionInput) (*ecs0.RegisterTaskDefinitionInput, *ecs.TaskConfigDiff) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplyTo", input)
@@ -157,7 +158,7 @@ func (m *MockECSDeployTaskConfig) ApplyTo(input *ecs0.RegisterTaskDefinitionInpu
 	return ret0, ret1
 }
 
-// ApplyTo indicates an expected call of ApplyTo
+// ApplyTo indicates an expected call of ApplyTo.
 func (mr *MockECSDeployTaskConfigMockRecorder) ApplyTo(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyTo", reflect.TypeOf((*MockECSDeployTaskConfig)(nil).ApplyTo), input)

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ func main() {
 	app := &cli.App{
 		Name:                   "ecs-ship",
 		Usage:                  "Deploy your aws ecs services.",
-		Version:                "1.0.0",
+		Version:                "1.1.0",
 		UseShortOptionHandling: true,
 		ArgsUsage:              "<cluster> <service>",
 		UsageText:              "ecs-deploy [options] <cluster> <service>",
@@ -43,6 +43,12 @@ func main() {
 				Name:     "no-color",
 				Aliases:  []string{"n"},
 				Usage:    "Disable colored output",
+				Required: false,
+			},
+			&cli.BoolFlag{
+				Name:     "no-wait",
+				Aliases:  []string{"w"},
+				Usage:    "Disable waiting for updates to be completed.",
 				Required: false,
 			},
 			&cli.BoolFlag{
@@ -78,7 +84,7 @@ func main() {
 			}
 
 			client := ecs.BuildDefaultClient()
-			return action.ECSDeploy(cluster, service, client, ctx.Duration("timeout"), &cfg, ctx.Bool("dry"))
+			return action.ECSDeploy(cluster, service, client, ctx.Duration("timeout"), &cfg, ctx.Bool("dry"), ctx.Bool("no-wait"))
 		},
 	}
 


### PR DESCRIPTION
Some times services just take too long to spin up.

We could create a second tool that just waits for a while until a service looks good and yells otherwise.
